### PR TITLE
Use new go-update API to fix build

### DIFF
--- a/gonative.go
+++ b/gonative.go
@@ -3,8 +3,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/inconshreveable/go-update"
-	"github.com/inconshreveable/go-update/check"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -15,6 +13,9 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/inconshreveable/go-update"
+	"github.com/inconshreveable/go-update/check"
 )
 
 // XXX: need checksum verification on these downloads


### PR DESCRIPTION
Tried installing gonative, got this:

```
➜  ~  go get -u github.com/inconshreveable/gonative
# github.com/inconshreveable/gonative
go/src/github.com/inconshreveable/gonative/gonative.go:434: not enough arguments in call to params.CheckForUpdate
go/src/github.com/inconshreveable/gonative/gonative.go:444: too many arguments in call to result.Update
```

Looks like it's been broken since go-update [ff213c4f3cdefad7eff541534f8e2219dec93b80](https://github.com/inconshreveable/go-update/commit/ff213c4f3cdefad7eff541534f8e2219dec93b80).

I also took the opportunity to switch to the newer go-update API that handles the initial check step automatically.

Finally, as a 2nd commit, I updated your imports to use goimports style. Feel free to skip that one if you don't prefer it.
