### PR TITLE
Native unpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ in your project's working directory. I use it mostly like this:
     
 ### Open Issues
 
-- gonative won't run on Windows because it uses unzip/tar unix utilities
+- gonative is untested on Windows
 
 ### Caveats
 - no linux/arm support because there are no official builds of linux/arm

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ gonative will not help you if your own packages rely on Cgo
     cd gonative
     make
 
-Alternatively, you can install gonative via `go get` but the dependenices are not
+Alternatively, you can install gonative via `go get` but the dependencies are not
 locked down.
 
     go get github.com/inconshreveable/gonative

--- a/gonative.go
+++ b/gonative.go
@@ -15,11 +15,7 @@ import (
 	log "gopkg.in/inconshreveable/log15.v2"
 )
 
-var Log log.Logger = log.New()
-
-func init() {
-	Log.SetHandler(log.DiscardHandler())
-}
+var Log = log.Root()
 
 const usage = `build Go installations with native stdlib packages
 
@@ -114,7 +110,6 @@ func buildCmd(c *cli.Context) {
 		}
 	}
 
-	Log = log.Root()
 	exit(Build(opts))
 }
 

--- a/unpack.go
+++ b/unpack.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func unpackFile(dest string, r io.Reader, fname string, mode os.FileMode) error {
+	dir, name := filepath.Split(fname)
+	dirPath := filepath.Join(dest, dir)
+	filePath := filepath.Join(dirPath, name)
+	if !strings.HasPrefix(filePath, dest) {
+		return fmt.Errorf("%q is outside of %s", fname, dest)
+	}
+	if err := os.MkdirAll(dirPath, 0755); err != nil {
+		return err
+	}
+	f, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	_, err = io.Copy(f, r)
+	return err
+}
+
+func unpackTarGz(dest string, r *os.File) error {
+	gr, err := gzip.NewReader(r)
+	if err != nil {
+		return err
+	}
+	tr := tar.NewReader(gr)
+	for {
+		f, err := tr.Next()
+		if err != nil {
+			if err == io.EOF {
+				err = nil
+			}
+			return err
+		}
+		if f.Typeflag != tar.TypeReg && f.Typeflag != tar.TypeReg {
+			continue
+		}
+		if err := unpackFile(dest, tr, f.Name, os.FileMode(f.Mode)); err != nil {
+			return err
+		}
+	}
+}
+
+func unpackZip(dest string, r *os.File) error {
+	stat, err := r.Stat()
+	if err != nil {
+		return err
+	}
+	zr, err := zip.NewReader(r, stat.Size())
+	if err != nil {
+		return err
+	}
+	for _, f := range zr.File {
+		if strings.HasSuffix(f.Name, "/") {
+			continue
+		}
+		fr, err := f.Open()
+		if err != nil {
+			return err
+		}
+		err = unpackFile(dest, fr, f.Name, f.Mode())
+		fr.Close()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
This patch uses the stdlib libraries to unpack archives instead of execing `tar`/`unzip`, which allows gonative to be used on systems that don't have those tools installed. Also, Windows support probably would only take a few minor changes (copy recursive, maybe some path tweaks) for someone to implement.

Closes #9