### PR TITLE
Add support for 1.5.1

### DIFF
--- a/gonative.go
+++ b/gonative.go
@@ -64,7 +64,7 @@ func main() {
 			Name:  "build",
 			Usage: "build a go installation with native stdlib packages",
 			Flags: []cli.Flag{
-				cli.StringFlag{"version", "1.4.3", "version of Go to build", ""},
+				cli.StringFlag{"version", "1.5.1", "version of Go to build", ""},
 				cli.StringFlag{"src", "", "path to go source, empty string means to fetch from internet", ""},
 				cli.StringFlag{"target", "go", "target directory in which to build Go", ""},
 				cli.StringFlag{"platforms", "", "space separated list of platforms to build, default is 'darwin_amd64 freebsd_amd64 linux_386 linux_amd64 windows_386 windows_amd64'", ""},
@@ -284,7 +284,8 @@ func distBootstrap(goRoot string, p Platform) (err error) {
 		Args: []string{scriptPath, "bootstrap", "-v"},
 		Env: append(os.Environ(),
 			"GOOS="+p.OS,
-			"GOARCH="+p.Arch),
+			"GOARCH="+p.Arch,
+			"GOROOT="+goRoot),
 		Dir:    scriptDir,
 		Stdout: os.Stdout,
 		Stderr: os.Stderr,

--- a/platform.go
+++ b/platform.go
@@ -138,6 +138,16 @@ func download(lg log15.Logger, rd io.Reader, name string, checksum string) (*os.
 }
 
 var checksums = map[string]string{
+	"https://storage.googleapis.com/golang/go1.5.1.src.tar.gz":                     "0df564746d105f4180c2b576a1553ebca9d9a124",
+	"https://storage.googleapis.com/golang/go1.5.1.darwin-amd64.tar.gz":            "02451b1f3b2c715edc5587174e35438982663672",
+	"https://storage.googleapis.com/golang/go1.5.1.darwin-amd64.pkg":               "857b77a85ba111af1b0928a73cca52136780a75d",
+	"https://storage.googleapis.com/golang/go1.5.1.freebsd-amd64.tar.gz":           "78ac27b7c009142ed0d86b899f1711bb9811b7e1",
+	"https://storage.googleapis.com/golang/go1.5.1.linux-386.tar.gz":               "6ce7328f84a863f341876658538dfdf10aff86ee",
+	"https://storage.googleapis.com/golang/go1.5.1.linux-amd64.tar.gz":             "46eecd290d8803887dec718c691cc243f2175fe0",
+	"https://storage.googleapis.com/golang/go1.5.1.windows-386.zip":                "bb071ec45ef39cd5ed9449b54c5dd083b8233bfa",
+	"https://storage.googleapis.com/golang/go1.5.1.windows-386.msi":                "034065452b7233b2a570d4be1218a97c475cded0",
+	"https://storage.googleapis.com/golang/go1.5.1.windows-amd64.zip":              "7815772347ad3e11a096d927c65bfb15d5b0f490",
+	"https://storage.googleapis.com/golang/go1.5.1.windows-amd64.msi":              "0a439f49b546b82f85adf84a79bbf40de2b3d5ba",
 	"https://storage.googleapis.com/golang/go1.4.3.src.tar.gz":                     "486db10dc571a55c8d795365070f66d343458c48",
 	"https://storage.googleapis.com/golang/go1.4.3.darwin-amd64.tar.gz":            "945666c36b42bf859d98775c4f02f807a5bdb6b0",
 	"https://storage.googleapis.com/golang/go1.4.3.darwin-amd64.pkg":               "3d91a21e3217370b80ca26e89a994e8199d583e7",


### PR DESCRIPTION
Adds support for building and bootstrapping 1.5.1.

1.5.1 does require you to set `GOROOT_BOOTSTRAP` correctly in order to bootstrap the compiler from an existing Go >= 1.4 compiler.
It also requires setting the `GOROOT` variable when bootstrapping a distribution to the target Go root path, it doesn't default to this anymore sadly, at least this we were able to set automatically, unlike the bootstrap root when is up to the user.