### PR TITLE
Update Godeps.json to fix make

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,31 +1,26 @@
 {
-	"ImportPath": "_/Users/aes/src/gonative",
-	"GoVersion": "go1.5.1",
+	"ImportPath": "github.com/inconshreveable/gonative",
+	"GoVersion": "go1.5.2",
 	"Packages": [
 		"github.com/inconshreveable/gonative"
 	],
 	"Deps": [
 		{
-			"ImportPath": "github.com/kardianos/osext",
-			"Comment": "null-15",
-			"Rev": "10da29423eb9a6269092eebdc2be32209612d9d2"
-		},
-		{
 			"ImportPath": "github.com/codegangsta/cli",
-			"Comment": "1.2.0-50-ga14c5b4",
-			"Rev": "a14c5b47c7efa4ff80cc42e1079a34b4756f2311"
+			"Comment": "1.2.0-179-g0302d39",
+			"Rev": "0302d3914d2a6ad61404584cdae6e6dbc9c03599"
 		},
 		{
 			"ImportPath": "github.com/inconshreveable/axiom",
-			"Rev": "d47f34fee0ce318eb07f0eee4b0e68b5662355ed"
-		},
-		{
-			"ImportPath": "github.com/inconshreveable/go-update",
-			"Rev": "8455de157e5e3eee5d680febf627fc4c03b59332"
+			"Rev": "89cf457954c8a5520c9281059ae4e5a8121eae7f"
 		},
 		{
 			"ImportPath": "github.com/inconshreveable/mousetrap",
 			"Rev": "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
+		},
+		{
+			"ImportPath": "github.com/kardianos/osext",
+			"Rev": "10da29423eb9a6269092eebdc2be32209612d9d2"
 		},
 		{
 			"ImportPath": "github.com/kr/binarydist",
@@ -33,12 +28,16 @@
 		},
 		{
 			"ImportPath": "github.com/mattn/go-colorable",
-			"Rev": "043ae16291351db8465272edf465c9f388161627"
+			"Rev": "3dac7b4f76f6e17fb39b768b89e3783d16e237fe"
+		},
+		{
+			"ImportPath": "gopkg.in/inconshreveable/go-update.v0",
+			"Rev": "d8b0b1d421aa1cbf392c05869f8abbc669bb7066"
 		},
 		{
 			"ImportPath": "gopkg.in/inconshreveable/log15.v2",
-			"Comment": "v2.7",
-			"Rev": "7cf5571b3b32a7c7b5605dc5ed8ad8fdbb2135f0"
+			"Comment": "v2.11",
+			"Rev": "b105bd37f74e5d9dc7b6ad7806715c7a2b83fd3f"
 		},
 		{
 			"ImportPath": "gopkg.in/yaml.v1",


### PR DESCRIPTION
Actually broke `make` with my previous pull request with update of `cli`. But `go get` works now. So I simply created a clean workspace, run `go get github.com/inconshreveable/gonative` followed by `godep save github.com/inconshreveable/gonative` and deleted `Godeps/_workspace`. This makes `make` work again and update all the deps to the most recent versions.